### PR TITLE
Add configurable proxy support

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,6 +29,8 @@ const cli = meow(`
 
     --proxy       Proxy requests to another server (only for dev)
 
+    --proxy-path  Path to proxy, default: /api
+
 `, {
   alias: {
     d: 'outDir',

--- a/lib/dev/index.js
+++ b/lib/dev/index.js
@@ -27,6 +27,7 @@ const start = async (filename, options, config) => {
   const Component = req.default || req
   const {
     proxy,
+    proxyPath = '/api',
     port = 8000
   } = options
 
@@ -51,7 +52,7 @@ const start = async (filename, options, config) => {
 
   if (proxy) {
     devOptions.proxy = {
-      '**': proxy
+      [proxyPath]: proxy
     }
   }
 


### PR DESCRIPTION
This allows an api and `x0 dev` to be used together. All
unknown `webpack-dev-server` requests are proxied to
the running api server.

```
x0 dev app/Index --proxy http://localhost:3000 | micro-dev
```