### PR TITLE
Add ability to specify config via package.json

### DIFF
--- a/lib/dev/index.js
+++ b/lib/dev/index.js
@@ -58,16 +58,16 @@ const start = async (filename, options, config) => {
 
   devOptions.contentBase = path.dirname(filename) // process.cwd()
 
-  if (pkgOpts.proxy) {
-    devOptions.proxy = pkgOpts.proxy
-  } else if (proxy) {
-    devOptions.proxy = {
+  if (proxy) {
+    opts.proxy = {
       [proxyPath]: proxy
     }
   }
 
+  const opts = Object.assign({}, devOptions, pkgOpts)
+
   const compiler = webpack(config)
-  const server = new DevServer(compiler, devOptions)
+  const server = new DevServer(compiler, opts)
 
   return new Promise((resolve, reject) => {
     compiler.plugin('done', () => {


### PR DESCRIPTION
Toying around with this idea, seems like it might be cleaner to do something like:

```json
{
  "scripts": {
    "build": "x0 build",
    "dev": "x0 dev | lab -d app -w | micro",
    "start": "micro"
  },
  "x0": {
    "entry": "app/App",
    "outDir": "public",
    "proxy": {
      "/api": "http://localhost:3000"
    }
  }
```

Instead of

```json
{
  "scripts": {
    "build": "x0 build app/App -d public",
    "dev": "x0 dev app/App --proxy http://localhost:3000 | lab -d app -w | micro",
    "start": "micro"
  }
}
```

***

One scenario where it'd be especially useful is for more complex proxy configurations where one might want to use regexes, multiple proxies or paths, etc.