### PR TITLE
Add node config to webpack configs

### DIFF
--- a/lib/dev/config.js
+++ b/lib/dev/config.js
@@ -39,6 +39,9 @@ module.exports = {
       }
     ]
   },
+  node: {
+    fs: 'empty'
+  },
   plugins: [
     new webpack.HotModuleReplacementPlugin()
   ]

--- a/lib/static/client.js
+++ b/lib/static/client.js
@@ -35,6 +35,9 @@ const config = {
       }
     ]
   },
+  node: {
+    fs: 'empty'
+  },
   plugins: []
 }
 


### PR DESCRIPTION
This allows `fs` to be required in a `getInitialProps` static method