### PR TITLE
Specify utf-8 encoding

### DIFF
--- a/lib/static/index.js
+++ b/lib/static/index.js
@@ -20,6 +20,7 @@ const createHTML = ({
   initialProps,
   scripts = []
 }) => (`<!DOCTYPE html>
+<head><meta charset='utf-8'></head>
 <div id='__APP__'>
 ${body}
 </div>


### PR DESCRIPTION
Without declaring utf-8, bundles using
utf-8 characters are unable to be parsed.