### PR TITLE
Add missing cxs dependency to React Router example

### DIFF
--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@compositor/x0": "^1.0.9",
+    "cxs": "^6.2.0",
     "react-router-dom": "^4.2.2"
   },
   "x0": {


### PR DESCRIPTION
Added the missing cxs dependency to the package.json within the React Router example.