### PR TITLE
Fixing cli script when the package.json is missing

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -46,7 +46,7 @@ const cli = meow(`
 })
 
 const [ cmd, file ] = cli.input
-const options = Object.assign({}, pkg.x0, cli.flags)
+const options = Object.assign({}, pkg ? pkg.x0 : {}, cli.flags)
 
 const absolute = f => f
   ? path.isAbsolute(f) ? f : path.join(process.cwd(), f)


### PR DESCRIPTION
I tried to quickly play with x0 and I realised that without a package.json the cli tool won't work. 
I appreciate the use case is probably not the most common, but 

1) it could put off people with less experience (not everyone is comfortable debugging npm dependencies)
2) the fix is rather trivial

so I thought it was a good idea to open a PR