### PR TITLE
Set dirname for dev server

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -60,6 +60,7 @@ module.exports = async (opts) => {
     config,
     dev,
     logLevel: 'error',
+    content: opts.dirname,
     port: opts.port,
     hot: { logLevel: 'error' },
     add: (app, middleware, options) => {


### PR DESCRIPTION
Fixes an issue where an `index.html` file in the cwd will take precedence over the dev server html