### PR TITLE
Remove webpack-hot-client alias

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const path = require('path')
 const webpack = require('webpack')
 const serve = require('webpack-serve')
@@ -34,6 +35,12 @@ module.exports = async (opts) => {
     opts.dirname,
     path.join(opts.dirname, 'node_modules')
   )
+
+  const whcAlias = config.resolve.alias['webpack-hot-client/client']
+  if (!fs.existsSync(whcAlias)) {
+    const whcPath = 'node_modules/webpack-hot-client/client'
+    config.resolve.alias['webpack-hot-client/client'] = path.join(process.cwd(), whcPath)
+  }
 
   config.plugins.push(
     new webpack.DefinePlugin({


### PR DESCRIPTION
Somewhere in the webpack deps and libraries an
alias is set for webpack-hot-client. Unfortunately
that dependency isn't necessarily where it thinks
it is when x0 is used as a library in another
package.

Related c8r/kit#169