### PR TITLE
Mdx parsing

### DIFF
--- a/lib/mdx-fm-loader.js
+++ b/lib/mdx-fm-loader.js
@@ -7,6 +7,7 @@ module.exports = async function (src) {
   const { content, data } = matter(src)
 
   const code = `export const frontMatter = ${stringifyObject(data)}
+
 ${content}
   `
   return callback(null, code)

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "license": "MIT",
   "dependencies": {
     "@compositor/log": "^1.0.0-0",
-    "@mdx-js/loader": "^0.11.0",
-    "@mdx-js/mdx": "^0.10.1",
-    "@mdx-js/tag": "^0.11.0",
+    "@mdx-js/loader": "^0.15.0",
+    "@mdx-js/mdx": "^0.15.0",
+    "@mdx-js/tag": "^0.15.0",
     "@rebass/markdown": "^1.0.0-1",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",

--- a/test/mdx-fm-loader.js
+++ b/test/mdx-fm-loader.js
@@ -16,7 +16,7 @@ test("mdx-fm-loader", async t => {
     async() {
       return (err, result) => {
         t.is(err, null, "mdx-fm-loader should not error");
-        t.throws(() => {
+        t.notThrows(() => {
           transform(mdx.sync(result), { presets: [env, react, stage0] });
         }, SyntaxError);
       };

--- a/test/mdx-fm-loader.js
+++ b/test/mdx-fm-loader.js
@@ -1,0 +1,27 @@
+import test from "ava";
+import mdx from "@mdx-js/mdx";
+import { transform } from "babel-core";
+import env from "babel-preset-env";
+import react from "babel-preset-react";
+import stage0 from "babel-preset-stage-0";
+
+import fmLoader from "../lib/mdx-fm-loader";
+
+const content = `# A Heading
+
+some other content`;
+
+test("mdx-fm-loader", async t => {
+  const loader = fmLoader.bind({
+    async() {
+      return (err, result) => {
+        t.is(err, null, "mdx-fm-loader should not error");
+        t.throws(() => {
+          transform(mdx.sync(result), { presets: [env, react, stage0] });
+        }, SyntaxError);
+      };
+    }
+  });
+
+  const cb = await loader(content);
+});


### PR DESCRIPTION
So if you use a bunch of mdx packages you can end up with a bunch of different mdx versions. Given the parsing changes that happen over mdx versions different mdx files can become invalid over different mdx version ranges. Currently (for mdx v0.15.0), this results in the generated frontmatter export conflicting with subsequent heading content, causing the babel loader to fail.

A temporary fix to this is to bump the versions to latest (0.15.0) here instead of the current (0.10.1) and add a newline under the inserted frontmatter. We have a similar newline insertion for our frontmatter support in gatsby-mdx, having run into this problem a couple times.

```
➜ yarn why @mdx-js/mdx
yarn why v1.9.4
warning package.json: No license field
[1/4] 🤔  Why do we have the module "@mdx-js/mdx"...?
[2/4] 🚚  Initialising dependency graph...
warning my-project@0.0.1: No license field
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "@mdx-js/mdx@0.15.0"
info Has been hoisted to "@mdx-js/mdx"
info Reasons this module exists
   - Hoisted from "mdx-deck#@mdx-js#mdx"
   - Hoisted from "mdx-deck#ok-cli#@mdx-js#mdx"
info Disk size without dependencies: "32MB"
info Disk size with unique dependencies: "436MB"
info Disk size with transitive dependencies: "1.21GB"
info Number of shared dependencies: 14
=> Found "@compositor/x0#@mdx-js/mdx@0.10.1"
info This module exists because "@compositor#x0" depends on it.
info Disk size without dependencies: "24MB"
info Disk size with unique dependencies: "444MB"
info Disk size with transitive dependencies: "1.21GB"
info Number of shared dependencies: 15
=> Found "@compositor/kit#@mdx-js/mdx@0.9.0"
info This module exists because "@compositor#kit" depends on it.
info Disk size without dependencies: "24MB"
info Disk size with unique dependencies: "444MB"
info Disk size with transitive dependencies: "1.21GB"
info Number of shared dependencies: 15
✨  Done in 1.24s.
```

* Commit #1 shows a test that throws after being passed to babel
* Commit #2 flips the test to notThrow, and shows it passing with the newline added.