### PR TITLE
Add missing comma to JSON example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Head elements such as `<title>`, `<meta>`, and `<style>` can be configured with 
 "x0": {
   "title": "My Site",
   "meta": [
-    { "name": "twitter:card", "content": "summary" }
+    { "name": "twitter:card", "content": "summary" },
     { "name": "twitter:image", "content": "kitten.png" }
   ],
   "links": [


### PR DESCRIPTION
A tiny fix to add a missing comma I noticed when copy & pasting the example into my `package.json`.