### PR TITLE
Set `webpack-dev-middleware` to fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "react-test-renderer": "^16.4.1",
     "refunk": "^3.0.1",
     "rimraf": "^2.6.2",
-    "sinon": "^6.0.0"
+    "sinon": "^6.0.0",
+    "webpack-dev-middleware": "3.6.0"
   },
   "x0": {
     "title": "x0",


### PR DESCRIPTION
Fixes: https://github.com/c8r/x0/issues/119

Since `webpack-dev-middleware` version 3.6.1 has been released, `koa-webpack` (imported by `webpack-serve`) breaks with that version and running x0 locally doesn't work. Since `webpack-serve` is using non-fixed versions, and so is `koa-webpack` I think the easiest fix here is to just set `webpack-dev-middleware` to a fixed version to avoid the issue. It adds another dependency that technically doesn't need to be there, but since `webpack-serve` is no longer maintained, it might be the best bet.